### PR TITLE
Update etui_module_tiff.c

### DIFF
--- a/src/bin/etui_config.c
+++ b/src/bin/etui_config.c
@@ -22,7 +22,7 @@
 #include <Elementary.h>
 
 #include "etui_config.h"
-#include "private.h"
+#include "etui_private.h"
 
 
 /*============================================================================*

--- a/src/modules/tiff/etui_module_tiff.c
+++ b/src/modules/tiff/etui_module_tiff.c
@@ -523,7 +523,7 @@ _etui_tiff_page_render_pre(void *d)
         md->page.has_begun = 1;
     }
     else
-        TIFFError("Etui", emsg);
+        TIFFError("Etui", "%s", emsg);
 }
 
 static void


### PR DESCRIPTION
error : format not a string literal and no format arguments [-Werror=format-security]